### PR TITLE
Added previous/next button support on presentation screen

### DIFF
--- a/voxxr-web/web/assets/css/voxxr.css
+++ b/voxxr-web/web/assets/css/voxxr.css
@@ -444,6 +444,13 @@
 #jqt .presentation.page .toggleFavorite.favorite {
   background: url('../img/favorite.png') no-repeat 8px 8px;
 }
+#jqt .presentation.page .nav span.ui-btn-inner {
+  padding-top: 0.1em;
+  padding-bottom: 0.4em;
+}
+#jqt .presentation.page .nav span.ui-btn-inner {
+  font-size: 0.6em;
+}
 #jqt .twuser .picture {
   display: block;
   float: left;

--- a/voxxr-web/web/assets/css/voxxr.less
+++ b/voxxr-web/web/assets/css/voxxr.less
@@ -435,7 +435,6 @@
         div.summary.allDetails {
             height: auto;
         }
-
         .toggleFavorite {
             display: block;
             float: right;
@@ -446,6 +445,13 @@
         }
         .toggleFavorite.favorite {
             background: url('../img/favorite.png') no-repeat 8px 8px;
+        }
+        .nav span.ui-btn-inner {
+            padding-top: 0.1em;
+            padding-bottom: 0.4em;
+        }
+        .nav span.ui-btn-inner {
+            font-size: 0.6em;
         }
     }
 

--- a/voxxr-web/web/assets/js/models-presentation.js
+++ b/voxxr-web/web/assets/js/models-presentation.js
@@ -70,7 +70,10 @@
         }
         self.time = ko.observable('');
         self.hotFactor = ko.observable(0);
-        self.hash = ko.computed(function() {return "#presentation~" + self.eventId() + "~" + self.id()});
+        function hashOf(eventId, presentationId){
+            return "#presentation~" + eventId + "~" + presentationId;
+        }
+        self.hash = ko.computed(function() {return hashOf(self.eventId(), self.id()) });
         self.my = ko.computed(function() {
             if (!models.User.current()) return null; // for dashboard and poll
             return models.User.current().my() ? models.User.current().my().presentation(self.eventId(), self.id()) : null
@@ -155,6 +158,46 @@
             _(self.speakers()).each(function(speaker) { speaker.load() });
         }
         self.quit = function() {}
+
+        function findAndSortPresentationsInCurrentSlot(){
+            var currentSlotPresentations = models.ScheduleDay.current()?models.ScheduleDay.current().data().schedule:[];
+            currentSlotPresentations = _.filter(currentSlotPresentations, function(presentation){
+                return models.Presentation.current() && presentation.slot === models.Presentation.current().data().slot;
+            });
+            currentSlotPresentations = _.sortBy(currentSlotPresentations, function(presentation){ return presentation.id; });
+            return currentSlotPresentations;
+        }
+        function findIndexForCurrentPresentationIn(presentations){
+            if(!models.Presentation.current()){
+                return -1;
+            }
+            var presentationIds = _.map(presentations, function(presentation){ return presentation.id; });
+            return _.indexOf(presentationIds, models.Presentation.current().data().id);
+        }
+        function findPresentationInSameSlot(delta){
+            var currentSlotPresentations = findAndSortPresentationsInCurrentSlot();
+            var currentPresentationIndex = findIndexForCurrentPresentationIn(currentSlotPresentations);
+
+            if(currentPresentationIndex === -1){
+                return null;
+            }
+
+            // modulo is a bitcomplicated here, due modulo bug (for negative numbers)
+            // more info here : http://javascript.about.com/od/problemsolving/a/modulobug.htm
+            return currentSlotPresentations[(currentPresentationIndex+currentSlotPresentations.length+delta)%currentSlotPresentations.length];
+        }
+        self.nextInSlot = ko.computed(function() {
+            return findPresentationInSameSlot(1);
+        });
+        self.previousInSlot = ko.computed(function(){
+            return findPresentationInSameSlot(-1);
+        });
+        self.nextInSlotHash = ko.computed(function() {
+            return self.nextInSlot()?hashOf(self.eventId(), self.nextInSlot().id):null;
+        });
+        self.previousInSlotHash = ko.computed(function() {
+            return self.previousInSlot()?hashOf(self.eventId(), self.previousInSlot().id):null;
+        });
     }
 
     Presentation.current = currentModelObject();

--- a/voxxr-web/web/m.html
+++ b/voxxr-web/web/m.html
@@ -245,7 +245,24 @@
             <a href="#" data-rel="back" data-icon="arrow-l">Back</a>
         </div>
         <div data-role="content">
-        <h2><a class="toggleFavorite" data-bind="css: { favorite: favorite }"></a> <span class="title" data-bind="text: title"> </span> <em><span class="slot" data-bind="text: slot"> </span> <span class="room" data-bind="text: room().name"> </span></em></h2>
+        <h2>
+            <a class="toggleFavorite" data-bind="css: { favorite: favorite }"></a> <span class="title" data-bind="text: title"> </span>
+            <a data-bind="href: previousInSlotHash" data-icon="arrow-l" class="nav ui-btn-left ui-btn ui-btn-up-a ui-btn-icon-left ui-btn-corner-all ui-shadow" data-corners="true" data-shadow="true" data-iconshadow="true" data-inline="false" data-wrapperels="span">
+                <span class="ui-btn-inner ui-btn-corner-all">
+                    <span class="ui-btn-text">Previous</span>
+                    <span class="ui-icon ui-icon-arrow-l ui-icon-shadow"></span>
+                </span>
+            </a>
+            <a data-bind="href: nextInSlotHash" data-icon="arrow-r" class="nav ui-btn-left ui-btn ui-btn-up-a ui-btn-icon-right ui-btn-corner-all ui-shadow" data-corners="true" data-shadow="true" data-iconshadow="true" data-inline="false" data-wrapperels="span">
+                <span class="ui-btn-inner ui-btn-corner-all">
+                    <span class="ui-btn-text">Next</span>
+                    <span class="ui-icon ui-icon-arrow-r ui-icon-shadow"></span>
+                </span>
+            </a>
+            <em>
+                <span class="slot" data-bind="text: slot"> </span> <span class="room" data-bind="text: room().name"> </span>
+            </em>
+        </h2>
         <a href="#roomRT" class="showroom" data-role="button" data-theme="e" data-transition="flip"
            data-bind="visible: playing">
             Show room now</a>


### PR DESCRIPTION
This is the first attempt, not really sure about everything I made... 

I'll provide some comments on particular lines..

Moreover, I didn't tested it on mobile emulator (didn't do this before ... I'll try to test this tomorrow) in order to see if prev/next button are not too large.

EDIT: I should rework the pull request to provide a "go back to schedule day screen" (namely "up") button.
See https://github.com/fcamblor/voxxrin/commit/3f16f7d7ee60ebf3fb2922cacb6b9ee17a0f29eb#voxxr-web/web/m.html-P1
